### PR TITLE
add delay to entrypoint script

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+sleep 25 # give minikube some time to create and mount the secret
 if [ -r '/usr/share/ca-certificates/extra/ca.crt' ]; then
     echo 'extra/ca.crt' >> /etc/ca-certificates.conf
     update-ca-certificates


### PR DESCRIPTION
This adds a 25 second delay to the entrypoint script, to give k8s some time to create and mount the tls secret. This is just a band-aid to make things work most of the time and should be refactored with a better solution.

